### PR TITLE
fixed category filter

### DIFF
--- a/server/api/categories.js
+++ b/server/api/categories.js
@@ -9,7 +9,7 @@ router.get('/', (req, res, next) => {
 })
 
 router.get('/:id', (req, res, next) => {
-  Product.findAll({where: {id: req.params.id}})
+  Product.findAll({where: {categoryId: req.params.id}})
     .then(products => res.json(products))
     .catch(next)
 })


### PR DESCRIPTION
Used Product.id instead of Product.categoryId in the Sequelize query. Fixed.